### PR TITLE
Reimplemented action logger to work with string builder

### DIFF
--- a/Wilbur/ActionLogModel.cpp
+++ b/Wilbur/ActionLogModel.cpp
@@ -7,6 +7,55 @@ ActionLogModel::ActionLogModel()
 	sessionTimer.start();
 }
 
+// Non Sim String Builder buildString implementation
+void ActionLogModel::buildStringAndAppend(std::string objectName, int newValue)
+{
+	QString returnText;
+
+	// check for button
+	if (objectName == "Switch One" || objectName == "Switch Two"
+		|| objectName == "Switch Three")
+	{
+		// Create button change string that will be shown in text window
+		returnText = QString("%1 changed to %2").arg(
+			 QString::fromStdString(objectName), newValue ? "Open" : "Closed");
+	}
+
+	else if (objectName == "Bluetooth Button")
+	{
+		// Create button change string that will be shown in text window
+		returnText = QString("%1 is %2").arg(QString::fromStdString(objectName),
+			newValue ? "Connected" : "Disconnected");
+	}
+
+	// Check for slider
+	else
+	{
+		// Create slider change string that will be shown in text window
+		std::string stiffnessString = "N/A";
+		switch (newValue)
+		{
+		case 0:
+			stiffnessString = "Off";
+			break;
+		case 1:
+			stiffnessString = "Low";
+			break;
+		case 2:
+			stiffnessString = "Med";
+			break;
+		case 3:
+			stiffnessString = "High";
+			break;
+		}
+
+		returnText = QString("Pump Stiffness set to %1").arg(
+			QString::fromStdString(stiffnessString));
+	}
+
+	addActionToLog(returnText);
+}
+
 void ActionLogModel::exportLog()
 {
 	// Create an IO stream to write into the file
@@ -28,7 +77,6 @@ void ActionLogModel::exportLog()
 void ActionLogModel::addActionToLog(QString actionToAdd)
 {
 	// Format action time and text
-	// @TODO: this should use the implemented version of stringBuilder
 	QString formattedAction = QString("%1 | %2 -> %3").arg(
 						 formattedElapsedTime(), getActionTime(), actionToAdd);
 

--- a/Wilbur/ActionLogModel.h
+++ b/Wilbur/ActionLogModel.h
@@ -3,6 +3,8 @@
 #define ACTIONLODMODEL_H
 
 // Header Files
+#include "IStringBuilder.h"
+
 #include <iostream>
 #include <ctime>
 #include <QFile>
@@ -15,12 +17,15 @@
 #include <QCoreApplication>
 
 // ActionLogModel Class derived as a QFile
-class ActionLogModel : public QFile
+class ActionLogModel : public QFile, public IStringBuilder
 {
 public:
 	// Action Log Constructor
 	ActionLogModel();
 	
+	// Build string with provided parameters and append result to list
+	void buildStringAndAppend(std::string objectName, int newValue);
+
 	// Export log as a txt file
 	void exportLog();
 

--- a/Wilbur/IStringBuilder.h
+++ b/Wilbur/IStringBuilder.h
@@ -11,9 +11,8 @@
 class IStringBuilder
 {
 public:
-
 	// Change in front end
-	virtual QString buildString(std::string objectName, int newValue) = 0;
+	virtual void buildStringAndAppend(std::string objectName, int newValue) = 0;
 
 };
 

--- a/Wilbur/InputDirectorViewModel.cpp
+++ b/Wilbur/InputDirectorViewModel.cpp
@@ -1,9 +1,10 @@
 #include "InputDirectorViewModel.h"
 
+InputDirectorViewModel::InputDirectorViewModel() : simulatorMode(true), 
+						     simObject(SimulatorModel()), simOutput(nullptr) {}
 
-InputDirectorViewModel::InputDirectorViewModel() : simulatorMode(true), simObject(SimulatorModel()), simOutput(nullptr) {}
-
-InputDirectorViewModel::InputDirectorViewModel(bool simState, QWidget* simOutputParent) : simulatorMode(simState), simOutput(nullptr)
+InputDirectorViewModel::InputDirectorViewModel(bool simState, 
+	    QWidget* simOutputParent) : simulatorMode(simState), simOutput(nullptr)
 {
 	if (simulatorMode)
 	{
@@ -11,13 +12,15 @@ InputDirectorViewModel::InputDirectorViewModel(bool simState, QWidget* simOutput
 
 		simOutput = new SimOutputViewModel(simOutputParent);
 	}
+
 	else 
 	{
 		// Initialize bluetooth connection object here
 	}
 }
 
-bool InputDirectorViewModel::handleInput(buttonType inputType, int newValue, std::string objectName) 
+bool InputDirectorViewModel::handleInput(buttonType inputType, int newValue, 
+											            std::string objectName) 
 {
 	bool hardwareResponse = false;
 
@@ -26,8 +29,6 @@ bool InputDirectorViewModel::handleInput(buttonType inputType, int newValue, std
 
 		switch (inputType)
 		{
-
-
 			case PUMP:
 				// cast newValue int to a pump enum value
 				hardwareResponse = simObject.setPump(static_cast<pumpValue>(newValue));

--- a/Wilbur/InputDirectorViewModel.h
+++ b/Wilbur/InputDirectorViewModel.h
@@ -23,13 +23,11 @@ public:
 	// bool handleInput(enum buttonType, double newValue, std::string objectName);
 
 private:
-
 	bool simulatorMode;
 
 	SimOutputViewModel* simOutput;
 
 	SimulatorModel simObject;
-
 };
 
 #endif // INPUTDIRECTORVIEWMODEL_H

--- a/Wilbur/SimOutputViewModel.cpp
+++ b/Wilbur/SimOutputViewModel.cpp
@@ -5,20 +5,24 @@
 #include "SimOutputViewModel.h"
 
 // Sim String Builder buildString implementation
-QString SimStringBuilder::buildString(std::string objectName, int newValue)
+void SimStringBuilder::buildStringAndAppend(std::string objectName, int newValue)
 {
     QString returnText;
+
     // check for button
-    if (objectName == "Button One" || objectName == "Button Two" || objectName == "Button Three")
+    if (objectName == "Switch One" || objectName == "Switch Two" 
+											   || objectName == "Switch Three")
     {
         // Create button change string that will be shown in text window
-        returnText = QString("%1 changed to %2").arg(QString::fromStdString(objectName)).arg(newValue ? "Open" : "Closed");
+        returnText = QString("%1 changed to %2").arg(
+			 QString::fromStdString(objectName), newValue ? "Open" : "Closed");
     }
 
     else if (objectName == "Bluetooth Button")
     {
         // Create button change string that will be shown in text window
-        returnText = QString("%1 is %2").arg(QString::fromStdString(objectName)).arg(newValue ? "Connected" : "Disconnected");
+        returnText = QString("%1 is %2").arg(QString::fromStdString(objectName), 
+									  newValue ? "Connected" : "Disconnected");
     }
 
     // Check for slider
@@ -42,16 +46,16 @@ QString SimStringBuilder::buildString(std::string objectName, int newValue)
             break;
         }
 
-        returnText = QString("Pump Stiffness set to %1").arg(QString::fromStdString(stiffnessString));
+        returnText = QString("Pump Stiffness set to %1").arg(
+									  QString::fromStdString(stiffnessString));
     }
 
     // Show text in window text history
     textList.append(returnText);
-
-    return returnText;
 }
 
-QStringList SimStringBuilder::getAllText() const {
+QStringList SimStringBuilder::getAllText() const 
+{
     // Return full list containing all strings regarding changes
     return textList;
 }
@@ -91,8 +95,9 @@ void SimOutputViewModel::initUI()
 // Handle text editor text manipulation
 void SimOutputViewModel::appendActionString(std::string objectName, int newValue) 
 {
-	// Using the text handler, control text manipulation
-    stringBuilder.buildString(objectName, newValue);
+	// Using the string builder, control text manipulation and append end 
+	// result to respective list
+    stringBuilder.buildStringAndAppend(objectName, newValue);
 
 	// Optionally update the text in the QTextEdit immediately
     textEdit->setPlainText(stringBuilder.getAllText().join("\n"));

--- a/Wilbur/SimOutputViewModel.h
+++ b/Wilbur/SimOutputViewModel.h
@@ -19,7 +19,7 @@
 class SimStringBuilder : IStringBuilder 
 {
 public:
-	QString buildString(std::string objectName, int newValue);
+	void buildStringAndAppend(std::string objectName, int newValue);
 
 	QStringList getAllText() const;
 

--- a/Wilbur/prototypeControllerView.cpp
+++ b/Wilbur/prototypeControllerView.cpp
@@ -5,7 +5,8 @@
 #include "PrototypeControllerView.h"
 
 // cite https://doc.qt.io/qt-6/qtwidgets-widgets-sliders-example.html
-PrototypeControllerView::PrototypeControllerView(QWidget* parent, ActionLogModel* actionLoggerPtr, InputDirectorViewModel* inputDirector)
+PrototypeControllerView::PrototypeControllerView(QWidget* parent, 
+	    ActionLogModel* actionLoggerPtr, InputDirectorViewModel* inputDirector)
 {
     // Create a wrapper for controls
     QWidget* controller = new QWidget;
@@ -21,23 +22,32 @@ PrototypeControllerView::PrototypeControllerView(QWidget* parent, ActionLogModel
 
     // create local variable to reference inputDirector
     director = inputDirector;
+
     // create assign member variable to reference actionLogger
     actionLog = actionLoggerPtr;
+
 	// Create bluetooth layout
     bluetoothLayout = new BluetoothLayoutView(this);
+
     // Connect layout to executeControl
-    connect(bluetoothLayout, &BluetoothLayoutView::bluetoothButtonClicked, this, &PrototypeControllerView::executeControl);
+    connect(bluetoothLayout, &BluetoothLayoutView::bluetoothButtonClicked, 
+							   this, &PrototypeControllerView::executeControl);
 
     // set ductLayout
     ductLayout = new DuctLayoutView(this);
+
     // Connect the signal from DuctLayoutView to executeControl slot
-    connect(ductLayout, &DuctLayoutView::ductButtonClicked, this, &PrototypeControllerView::executeControl);
+    connect(ductLayout, &DuctLayoutView::ductButtonClicked, this, 
+									 &PrototypeControllerView::executeControl);
 
     // @TODO: Need to log the milk viscocity values 
    /* connect(ductLayout, &DuctLayoutView::ductFlowRateChanged, this, &PrototypeControllerView::executeFlowRateControl);*/
-    // Create a slider layout containing slider and its labels
+    
+	// Create a slider layout containing slider and its labels
     sliderLayout = new SliderLayoutView(this);
-    connect(sliderLayout->stiffnessSlider, &StiffnessSliderView::sliderReleased, this, [this]() {executeControl(PUMP, sliderLayout->stiffnessSlider->value()); });
+    connect(sliderLayout->stiffnessSlider, &StiffnessSliderView::sliderReleased, 
+										   this, [this]() {executeControl(PUMP, 
+								   sliderLayout->stiffnessSlider->value()); });
 
     // Full PrototypeControllerView Layout
     QVBoxLayout* controlLayout = new QVBoxLayout;
@@ -46,7 +56,6 @@ PrototypeControllerView::PrototypeControllerView(QWidget* parent, ActionLogModel
     controlLayout->addWidget(controlLabel);
     controlLayout->addWidget(ductLayout);
     controlLayout->addWidget(sliderLayout);
-    
     controller->setLayout(controlLayout);
 
     //Set style for PrototypeControllerView label
@@ -60,19 +69,21 @@ void PrototypeControllerView::executeControl(buttonType button, int newValue)
     std::string objectName = "N/A";
     bool actionSuccess = false;
 
+	// IMPORTANT: This will transferred to stringBuilder sometime in the
+	// future, this is here temporarily
     switch (button)
     {
         case PUMP:
             objectName = "Pump Slider";
             break;
         case VALVE1:
-            objectName = "Button One";
+            objectName = "Switch One";
             break;
         case VALVE2:
-            objectName = "Button Two";
+            objectName = "Switch Two";
             break; 
         case VALVE3:
-            objectName = "Button Three";
+            objectName = "Switch Three";
             break;
         case CONNECT:
             objectName = "Bluetooth Button";
@@ -80,12 +91,11 @@ void PrototypeControllerView::executeControl(buttonType button, int newValue)
     }
 
     actionSuccess = director->handleInput(button, newValue, objectName);
+	
+    // At action logger, build string and append it to list of actions
+	actionLog->buildStringAndAppend(objectName, newValue);
 
-    // @TODO: make function call to actionlogger here
     // @TODO: also need to handle milk viscocity change to output to log
-    // textHandler.getActionText()
-    actionLog->addActionToLog("Previously this was stringBuilder.getActionText()");
-
 }
 
 PrototypeControllerView::~PrototypeControllerView()


### PR DESCRIPTION
- Changed buildString in IStringBuilder.h to buildStringAndAppend and made it a void since there was no use of the returned value
- Created version of buildStringAndAppend for actionLogger
- Added and deleted whitespace where readability needed improvements
- Changed "Button One/Two/Three" to "Switch One/Two/Three" (per Dr. Mayerl's personal preference)