### PR TITLE
Fixed spin box logging issues

### DIFF
--- a/Wilbur/FlowRateLayoutView.cpp
+++ b/Wilbur/FlowRateLayoutView.cpp
@@ -3,8 +3,6 @@
 FlowRateLayoutView::FlowRateLayoutView(ConnectionButtonView* connectionButton, QWidget* parent) 
     : QWidget(parent), connectButton(connectionButton)
 {
-	previousValue = 0;
-
     QHBoxLayout* layout = new QHBoxLayout(this);
 
 	setToolTip("Press Enter to log Flow Rate changes");
@@ -14,6 +12,11 @@ FlowRateLayoutView::FlowRateLayoutView(ConnectionButtonView* connectionButton, Q
     flowSpinBox->setMaximumWidth(75);
     flowSpinBox->setFixedHeight(20);
     flowSpinBox->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
+
+	// Set keyboard tracking to false so that the spin box value only changes
+	// when the user is done typing by pressing Enter or using the spin box 
+	// arrows
+	flowSpinBox->setKeyboardTracking(false);
 
     flowUnitLabel = new QLabel("m<sup>3</sup>/s");
     flowUnitLabel->setStyleSheet("font: bold 12px; ");
@@ -73,11 +76,5 @@ void FlowRateLayoutView::handleValueChanged()
 		return;
     }
 
-	if (spinBoxValue != previousValue)
-	{
-		spinBoxValue = flowSpinBox->value();
-
-		previousValue = spinBoxValue;
-	}
-
+	spinBoxValue = flowSpinBox->value();
 }

--- a/Wilbur/FlowRateLayoutView.h
+++ b/Wilbur/FlowRateLayoutView.h
@@ -34,9 +34,7 @@ private:
 	// create value input labels
 	QDoubleSpinBox* flowSpinBox;
 
-	double spinBoxValue;
-
-	double previousValue;
+	double spinBoxValue = 0;
 };
 
 #endif // FLOWRATELAYOUTVIEW_H

--- a/Wilbur/SwitchLayoutView.cpp
+++ b/Wilbur/SwitchLayoutView.cpp
@@ -73,8 +73,9 @@ QHBoxLayout* SwitchLayoutView::createButtonLayout(const QString& labelText, Swit
 	// instantiate value box
 	*flowLayout = new FlowRateLayoutView(connectButton);
 
+
 	// set event handler for when flow rate is changed
-	connect((*flowLayout)->getSpinBox(), &QDoubleSpinBox::editingFinished, this,
+	connect((*flowLayout)->getSpinBox(), &QDoubleSpinBox::valueChanged, this,
 		[this, valveType, flowLayout]() {callExecuteFlowRateControl(valveType, 
 										 (*flowLayout)->getSpinBox()->value());
 		});
@@ -109,13 +110,7 @@ void SwitchLayoutView::callExecuteFlowRateControl(buttonType button, double newV
 {
 	if (connectButton->getState())
 	{
-		if (newValue != previousValue)
-		{
-			previousValue = newValue;
-
-			emit switchFlowRateChanged(button, newValue);
-		}
-
+		emit switchFlowRateChanged(button, newValue);
 	}
 
 }

--- a/Wilbur/SwitchLayoutView.h
+++ b/Wilbur/SwitchLayoutView.h
@@ -55,7 +55,6 @@ private:
 	FlowRateLayoutView* flowRateOne;
 	FlowRateLayoutView* flowRateTwo;
 	FlowRateLayoutView* flowRateThree;
-	double previousValue = 0;
 
 	// create layout variable
 	QHBoxLayout* horizontalLabelLayout;
@@ -67,8 +66,9 @@ private:
 	QHBoxLayout* buttonLayout;
 
 	// functions
-	QHBoxLayout* createButtonLayout(const QString& labelText, SwitchButtonView** button, FlowRateLayoutView** flowLayout, buttonType valveType);
-
+	QHBoxLayout* createButtonLayout(const QString& labelText, 
+					SwitchButtonView** button, FlowRateLayoutView** flowLayout, 
+														 buttonType valveType);
 };
 
 #endif // SWITCHLAYOUTVIEW_H


### PR DESCRIPTION
- Added line of code that disables keyboard tracking when editing spin box to avoid multiple loggings
- Reverted changes made in PR #136 as they are not needed 
- Found solution here: https://forum.qt.io/topic/111377/qspinbox-editingfinished-signal-on-up-down-arrow-press/9